### PR TITLE
add navigation back to transaction history after editing transaction

### DIFF
--- a/src/components/AddTransaction/index.js
+++ b/src/components/AddTransaction/index.js
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react';
-import {useParams} from 'react-router-dom';
+import {useNavigate, useParams} from 'react-router-dom';
 
 import useStore from '../../hooks/useStore';
 import {Form} from '../AddNewAccount/styled';
@@ -14,6 +14,7 @@ export default function AddTransaction() {
 	);
 	const addTransaction = useStore(state => state.addTransaction);
 	const editTransaction = useStore(state => state.editTransaction);
+	const navigate = useNavigate();
 
 	useEffect(() => {
 		if (currentTransaction) {
@@ -39,6 +40,7 @@ export default function AddTransaction() {
 						addTransaction(accountID, transaction);
 					}
 					setTransaction(initialValue);
+					navigate('/' + accountID);
 				}}
 			>
 				<label htmlFor="date">Date</label>

--- a/src/pages/formTransaction.js
+++ b/src/pages/formTransaction.js
@@ -3,7 +3,7 @@ import AddTransaction from '../components/AddTransaction';
 export default function FormTransaction() {
 	return (
 		<>
-			<h1>Add a new Transaction</h1>
+			<h1>Transaction</h1>
 			<AddTransaction />
 		</>
 	);


### PR DESCRIPTION
The user will now the navigated back to the transaction history of the chosen account after editing/adding a transaction. 